### PR TITLE
Add go install and releases link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#cidr2ip
+# cidr2ip
 
 This program converts IPv4 CIDR blocks into their constituent IP addresses.
 
@@ -31,15 +31,12 @@ code@express:~$ cidr2ip -f cidrs.txt
 
 #### Download from the releases pages
 
-Download pre-built binary from the release page.
-```
+Download pre-built binary from the [releases page](https://github.com/codeexpress/cidr2ip/releases).
 
-```
-
-#### Use `go get`
+#### Use `go install`
 
 If you have `golang` tools installed, you can download and build the source code
 locally as follows:
 ```
-
+go install github.com/codeexpress/cidr2ip@latest
 ```


### PR DESCRIPTION
Hi, just a little PR to add the missing go install (instead of go get) to the README, and also make the "releases page" a link, and fix the top header typo.