### PR TITLE
Add -r flag to print IP ranges

### DIFF
--- a/cidr2ip.go
+++ b/cidr2ip.go
@@ -18,6 +18,8 @@ const (
 var (
 	cidrFilePtr = flag.String("f", "",
 		"[Optional] Name of file with CIDR blocks")
+	printRangesPtrPtr = flag.Bool("r", false,
+		"[Optional] Print IP ranges instead of all IPs")
 )
 
 func main() {
@@ -50,8 +52,15 @@ func main() {
 			displayIPs(scanner.Text())
 		}
 	} else if len(args) > 0 { // look for CIDRs on cmd line
-		for _, ip := range args {
-			displayIPs(ip)
+		var cidrs []string
+		if *printRangesPtrPtr == true {
+			cidrs = args[1:]
+		} else {
+			cidrs = args
+		}
+
+		for _, cidr := range cidrs {
+			displayIPs(cidr)
 		}
 	} else { // no piped input, no file provide and no args, display usage
 		flag.Usage()
@@ -87,8 +96,12 @@ func displayIPs(cidr string) {
 		return
 	}
 
-	for _, ip := range ips[1 : len(ips)-1] {
-		fmt.Println(ip)
+	if *printRangesPtrPtr == true {
+		fmt.Printf("%s-%s\n", ips[1], ips[len(ips)-1])
+	} else {
+		for _, ip := range ips[1 : len(ips)-1] {
+			fmt.Println(ip)
+		}
 	}
 }
 
@@ -105,9 +118,11 @@ func increment(ip net.IP) {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "CIDR to IPs version %s\n", Version)
-	fmt.Fprintf(os.Stderr, "Usage:   $ cidr2ip [-f <filename>] <list of cidrs> \n")
+	fmt.Fprintf(os.Stderr, "Usage:   $ cidr2ip [-r] [-f <filename>] <list of cidrs> \n")
 	fmt.Fprintf(os.Stderr, "Example: $ cidr2ip -f cidrs.txt\n")
 	fmt.Fprintf(os.Stderr, "         $ cidr2ip 10.0.0.0/24\n")
+	fmt.Fprintf(os.Stderr, "         $ cidr2ip -r 10.0.0.0/24\n")
+	fmt.Fprintf(os.Stderr, "         $ cidr2ip -r -f cidrs.txt\n")
 	fmt.Fprintf(os.Stderr, "         $ cat cidrs.txt | cidr2ip \n")
 	fmt.Fprintf(os.Stderr, "--------------------------\nFlags:\n")
 	flag.PrintDefaults()

--- a/cidr2ip.go
+++ b/cidr2ip.go
@@ -97,7 +97,7 @@ func displayIPs(cidr string) {
 	}
 
 	if *printRangesPtrPtr == true {
-		fmt.Printf("%s-%s\n", ips[1], ips[len(ips)-1])
+		fmt.Printf("%s-%s\n", ips[1], ips[len(ips)-2])
 	} else {
 		for _, ip := range ips[1 : len(ips)-1] {
 			fmt.Println(ip)


### PR DESCRIPTION
Hi, this PR adds a `-r` flag that allows to print IP ranges instead of all IPs, which can be very heavy and slow.

Before:
```
$ cidr2ip 10.0.0.0/24
10.0.0.1
10.0.0.2
10.0.0.3
10.0.0.4
10.0.0.5
[...]
10.0.0.250
10.0.0.251
10.0.0.252
10.0.0.253
10.0.0.254
```

After:
```
$ cidr2ip -r 10.0.0.0/24
10.0.0.1-10.0.0.254

$ cidr2ip
CIDR to IPs version 1.0.0
Usage:   $ cidr2ip [-r] [-f <filename>] <list of cidrs> 
Example: $ cidr2ip -f cidrs.txt
         $ cidr2ip 10.0.0.0/24
         $ cidr2ip -r 10.0.0.0/24
         $ cidr2ip -r -f cidrs.txt
         $ cat cidrs.txt | cidr2ip 
--------------------------
Flags:
  -f string
        [Optional] Name of file with CIDR blocks
  -r    [Optional] Print IP ranges instead of all IPs
```

Fixes #1 